### PR TITLE
Make `Rails/ServiceName` namespace-aware

### DIFF
--- a/lib/rubocop/cop/obsession/rails/service_name.rb
+++ b/lib/rubocop/cop/obsession/rails/service_name.rb
@@ -50,7 +50,7 @@ module RuboCop
 
           def on_class(class_node)
             return if public_methods(class_node).length != 1
-            class_name = class_node.identifier.source
+            class_name = class_node.identifier.source.split('::').last
             class_name_first_word = class_name.underscore.split('_').first
 
             add_offense(class_node) if !verb?(class_name_first_word)


### PR DESCRIPTION
Services can be namespaced (e.g. `Billing::ProcessOrder`), so I think this cop should make sure to detect "process" as the start of the service name, not "billing"